### PR TITLE
(fix): resolve title in card property add condition

### DIFF
--- a/src/components/common/PropertiesCard.jsx
+++ b/src/components/common/PropertiesCard.jsx
@@ -64,7 +64,7 @@ const PeropertiesCard = ({ item }) => {
             {/* Title and time */}
             <div className="flex flex-col justify-between gap-2 sm:flex-row sm:items-center sm:gap-0">
               <h3 className="text-lg font-semibold text-black capitalize sm:text-xl">
-                {title.slice(9, 40)}
+                {title.includes("Te huur:") ? title.slice(9, 31) : title}
               </h3>
               <div className="flex items-center gap-1.5 text-sm text-gray-500">
                 <FiClock size={15} />


### PR DESCRIPTION
Added a title condition and methods like if 0, 9 = "Te huur:" exist, then it removes the character, otherwise it will show the full title.